### PR TITLE
Initial implementation of Mayhem fuzzing

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  MAYHEMFILE: Mayhemfile
+  PROJECTNAME: gjson-rs
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis of gjson.rs fuzzing target
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,21 @@
+# Use the example in Mayhem Docs as an example/starting point
+FROM rust:1.60-buster as rust-builder
+RUN cargo install afl
+
+# Add the source code to the image and build the target
+ADD . /gjson.rs
+WORKDIR /gjson.rs/extra/fuzz
+RUN cargo afl build
+# Built target is: /gjson.rs/extra/fuzz/target/debug/fuzz
+
+# To simplify matters, we'll copy the compiled target as well as
+# the fuzz input folder to a new image with AFL. This helps save some space.
+FROM --platform=linux/amd64 rust:1.60-buster
+RUN cargo install afl
+
+# Copy the compiled target and the input cases
+COPY --from=rust-builder /gjson.rs/extra/fuzz/target/debug/fuzz /gjson.rs/extra/fuzz/in /
+
+# Set to fuzz!
+ENTRYPOINT ["cargo", "afl", "fuzz", "-i", "/in", "-o", "/out"]
+CMD ["/fuzz"]

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,0 +1,9 @@
+project: gjson-rs
+target: main-fuzz
+duration: 300
+
+cmds:
+  - cmd: /fuzz
+    env:
+      DISABLE_SMOKETEST: '1'
+    afl: true

--- a/extra/fuzz/src/main.rs
+++ b/extra/fuzz/src/main.rs
@@ -21,8 +21,8 @@ const JSON: &str = r#"
 fn main() {
     fuzz!(|data: &[u8]| {
         if let Ok(s) = from_utf8(data) {
-            let _ = from_utf8(gjson::get(s, s).raw().as_bytes()).unwrap();
-            let _ = from_utf8(gjson::get(JSON, s).raw().as_bytes()).unwrap();
+            let _ = from_utf8(gjson::get(s, s).json().as_bytes()).unwrap();
+            let _ = from_utf8(gjson::get(JSON, s).json().as_bytes()).unwrap();
         }
     });
 }


### PR DESCRIPTION
Implementation of Mayhem fuzzing for the `gjson.rs` project. This includes a Dockerfile, Mayhemfile, and GitHub Action for Mayhem. Integration was straightforward, although the project name for Mayhem was manually changed to `gjson-rs` for compatibility. The fuzzing files were also fixed, as they were initially broken in the project.